### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -45,6 +45,20 @@
             }
         };
 
+        //Display Blacklisted
+        bot.commands.displayBlacklisted = {
+            command: ['displaybl', 'dbl'],
+            rank: 'user', //Feel free to change this if you want, I suggest only managers be able to use this
+            type: 'exact',
+            functionality: function (chat, cmd) {
+                if (this.type === 'exact' && chat.message.length !== cmd.length) return void (0);
+                if (!bot.commands.executable(this.rank, chat)) return void (0);
+                else {
+                    bot.logNewBlacklistedSongs();
+                }
+            }
+        };
+
         //Load the chat package again to account for any changes
         bot.loadChat();
 


### PR DESCRIPTION
Added new command 'displaybl' or 'dbl'. It will print the information of newly blacklisted songs to your browser's console.
