### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -21,6 +21,20 @@
             }
         }, 1000 * 60 * 60);
 
+        API.on(API.ADVANCE, function () {
+            var toggle = $(".cycle-toggle");
+            if(API.getWaitList().length > 20) {
+                if (!toggle.hasClass("disabled")) {
+                    toggle.click();
+                }
+            }
+            if(API.getWaitList().length < 15) {
+                if (toggle.hasClass("disabled")) {
+                    toggle.click();
+                }
+            }
+        });
+
         /*
          Extend the bot here, either by calling another function or here directly.
          Model code for a bot command:


### PR DESCRIPTION
This will auto-disable the DJ cycle if the wait list reaches 21 people and enable it when it reaches 14, theoretically... I haven't been able to test it because I don't have a room with more than 20 people in it, enabling it works though! (I don't have a room with even 1 person other than me in it :p)
